### PR TITLE
Fixed Big Sur fetch "method 1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## **Macinabox**
+## **Macinabox Redux**
+
+### This is a fork of Macinabox by SpaceinvaderOne. It adds proper support for macOS Big Sur and refactors some of the code for cleanliness.
+
+This fork is not currently available in Unraid's community applications, so you'll need to deploy the repository to Docker yourself for now.
+
+#### Original Readme Below
 
 This is a container to be run on an Unraid server. It will help with the setup of a MacOS VM.
 To use this please install through Unraid's community applications but you can see the template here https://raw.githubusercontent.com/SpaceinvaderOne/Docker-Templates-Unraid/master/spaceinvaderone/macinabox.xml
@@ -7,5 +13,3 @@ Macinabox will download and install Big Sur, Catalina, Mojave or High Sierra. It
 Macinabox installs a userscript to the server that when run will also fix any xml in the macOS vm after having been edited in the Unraid VM Manager.
 
 If you have a version of macinabox installed before Dec 9 2020 then please make sure to delete the old container template and apdata before installing the new version.
-
-

--- a/tools/FetchMacOS/fetch.sh
+++ b/tools/FetchMacOS/fetch.sh
@@ -8,7 +8,7 @@ cd "$SCRIPTDIR" || exit
 # Big Sur uses script 2 for method 1
 if [ "$method" = "method 1" ] && [ "$flavour" == "Big Sur" ] ; then		
 # python3 fetch-macos2.py
-python3 fetch-macos.py # temporary use other big sur download method for now
+python3 fetch-macos.py "$@" # temporary use other big sur download method for now
 # others uses script 1 for method 1
 elif [ "$method" = "method 1" ] ; then
 python3 fetch-macos.py "$@"

--- a/unraid.sh
+++ b/unraid.sh
@@ -247,7 +247,7 @@ fi
 			echo "I am going to download the BigSur recovery media. Please be patient!"
 		    echo "."
 		    echo "."
-	    "/Macinabox/tools/FetchMacOS/fetch.sh" -v 10.16 -c PublicRelease -p 001-86606 || exit 1;
+	    "/Macinabox/tools/FetchMacOS/fetch.sh" -v 10.16 -c PublicRelease -p 071-05432 || exit 1;
 		
 	else
 		echo "Media already exists. I have already downloaded the Big Sur install media before"


### PR DESCRIPTION
Parameters passed to fetch.sh were not being sent to fetch-macos.py when fetch "method 1" was selected, resulting in the script downloading 10.15 Catalina by default instead of Big Sur as intended.

Fixes issue #33.