### PR TITLE
Fix BaseSystem.img boot and change of Big Sur product id

### DIFF
--- a/unraid.sh
+++ b/unraid.sh
@@ -247,7 +247,7 @@ fi
 			echo "I am going to download the BigSur recovery media. Please be patient!"
 		    echo "."
 		    echo "."
-	    "/Macinabox/tools/FetchMacOS/fetch.sh" -v 10.16 -c PublicRelease -p 071-05432 || exit 1;
+	    "/Macinabox/tools/FetchMacOS/fetch.sh" -v 10.16 -c PublicRelease -p 071-00696 || exit 1;
 		
 	else
 		echo "Media already exists. I have already downloaded the Big Sur install media before"


### PR DESCRIPTION
The current OpenCore.img is unable to boot Big Sur 11.4.
Moreover, if BaseSystem.dmg is converted to img SecureBootModel different than Disabled causes the vm to bootloop.
The new OpenCore raw image of this PR is updated to v. 0.7.0 debug with:
VirtualSMC: v. 1.2.4 (debug) stable (included in case the xml is messed, lacking the oskey key)
AppleALC: v. 1.6.1 (debug) stable
Whatevergreen: v. 1.5.0 (debug) stable
Lilu: v. 1.5.3 (debug) stable

DhinakG - cpuid_set_cpufamily - force CPUFAMILY_INTEL_PENRYN patch was added too for big sur 11.3+ (in case the user changes from penryn emulation to intel passthrough).

This is a workaround to boot the converted BaseSystem.img.
The correct method to install from BaseSystem is described here:
https://forums.unraid.net/topic/84601-support-spaceinvaderone-macinabox/?do=findComment&comment=1010581

Product id for Big Sur 11.4 was updated too.