### PR TITLE
Fixed features, topology, clock, hpet, and cpu to host and qemucommandline settings

### DIFF
--- a/xml/Macinabox BigSur.xml
+++ b/xml/Macinabox BigSur.xml
@@ -23,14 +23,17 @@
   <features>
     <acpi/>
     <apic/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
   </features>
   <cpu mode='host-passthrough' check='none'>
-    <topology sockets='1' cores='2' threads='1'/>
+    <topology sockets='1' dies='1' cores='1' threads='2'/>
   </cpu>
-  <clock offset='utc'>
+  <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>
-    <timer name='hpet' present='no'/>
+    <timer name='hpet' present='yes'/>
   </clock>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
@@ -140,6 +143,6 @@
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
+    <qemu:arg value='host,vendor=GenuineIntel,+invtsc,kvm=on'/>
   </qemu:commandline>
 </domain>

--- a/xml/Macinabox Catalina.xml
+++ b/xml/Macinabox Catalina.xml
@@ -23,14 +23,17 @@
   <features>
     <acpi/>
     <apic/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
   </features>
   <cpu mode='host-passthrough' check='none'>
-    <topology sockets='1' cores='2' threads='1'/>
+    <topology sockets='1' dies='1' cores='1' threads='2'/>
   </cpu>
-  <clock offset='utc'>
+  <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>
-    <timer name='hpet' present='no'/>
+    <timer name='hpet' present='yes'/>
   </clock>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
@@ -141,6 +144,6 @@
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
+    <qemu:arg value='host,vendor=GenuineIntel,+invtsc,kvm=on'/>
   </qemu:commandline>
 </domain>

--- a/xml/Macinabox HighSierra.xml
+++ b/xml/Macinabox HighSierra.xml
@@ -23,14 +23,17 @@
   <features>
     <acpi/>
     <apic/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
   </features>
   <cpu mode='host-passthrough' check='none'>
-    <topology sockets='1' cores='2' threads='1'/>
+    <topology sockets='1' dies='1' cores='1' threads='2'/>
   </cpu>
-  <clock offset='utc'>
+  <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>
-    <timer name='hpet' present='no'/>
+    <timer name='hpet' present='yes'/>
   </clock>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
@@ -140,6 +143,6 @@
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
+    <qemu:arg value='host,vendor=GenuineIntel,+invtsc,kvm=on'/>
   </qemu:commandline>
 </domain>

--- a/xml/Macinabox Mojave.xml
+++ b/xml/Macinabox Mojave.xml
@@ -20,17 +20,20 @@
       <loader readonly='yes' type='pflash'>/mnt/user/system/custom_ovmf/Macinabox_CODE-pure-efi.fd</loader>
 	  <nvram>/mnt/user/system/custom_ovmf/Macinabox_VARS-pure-efi.fd</nvram>
   </os>
-  <features>
+ <features>
     <acpi/>
     <apic/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
   </features>
   <cpu mode='host-passthrough' check='none'>
-    <topology sockets='1' cores='2' threads='1'/>
+    <topology sockets='1' dies='1' cores='1' threads='2'/>
   </cpu>
-  <clock offset='utc'>
+  <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>
-    <timer name='hpet' present='no'/>
+    <timer name='hpet' present='yes'/>
   </clock>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
@@ -140,6 +143,6 @@
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
+    <qemu:arg value='host,vendor=GenuineIntel,+invtsc,kvm=on'/>
   </qemu:commandline>
 </domain>


### PR DESCRIPTION
- Added feature to hide the hypervisor from macOS.
- Fixed topology to allow OpenCore to detect and report it correctly to macOS.
- Changed clock to localtime, so macOS will always be in sync with UnRAID's time.
- Changed HPET to be enabled in macOS (fixes some TSC Sync issues on AMD systems).
- Changed CPU type to host because naming CPU is not needed, plus only added the required CPU features and removed all others since passing through as host will pass through all other CPU features as well. This works for both AMD and Intel CPUs.