### PR TITLE
Fix board id for Big Sur

### DIFF
--- a/tools/FetchMacOS/fetch-macos2.py
+++ b/tools/FetchMacOS/fetch-macos2.py
@@ -479,7 +479,7 @@ def main():
             {"name": "Mojave (10.14)", "b": "Mac-7BA5B2DFE22DDD8C", "m": "00000000000KXPG00"},
             {"name": "Catalina (10.15) - RECOMMENDED", "b": "Mac-00BE6ED71E35EB86", "m": "00000000000000000"},
             # {"name": "Latest (Big Sur - 11)", "b": "Mac-E43C1C25D4880AD6", "m": "00000000000000000", "os_type": "latest"}
-            {"name": "Latest (Big Sur - 11)", "b": "Mac-E43C1C25D4880AD6", "m": "00000000000000000", "os_type": "default"}
+            {"name": "Latest (Big Sur - 11)", "b": "Mac-2BD1B31983FE1663", "m": "00000000000000000", "os_type": "default"}
             ]
 
     for index, product in enumerate(products):


### PR DESCRIPTION
Old board id Mac-00BE6ED71E35EB86 in fetch-macos2 may be unable to download the correct recovery image for Big Sur, in fact it downloads Monterey.
Board id is updated to Mac-2BD1B31983FE1663, accordingly to commit of original source:https://github.com/acidanthera/OpenCorePkg/commit/b34c2ddfda2c712fcc0517e9d976a2b3d683edd7

This downloads a recovery image of Big Sur 11.6.