### PR TITLE
Fix docker image compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add \
     apk add openssh-askpass --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
     && rm -rf /var/cache/apk/* /tmp/* /tmp/.[!.]*
 
-# Download virt-manager from git
-RUN git clone https://github.com/virt-manager/virt-manager.git
+# Download virt-manager from git and switch to release 3.2.0
+RUN git clone https://github.com/virt-manager/virt-manager.git && cd virt-manager && git checkout ddc55c8
 
 # Install virt-manager with script from developer
 RUN cd virt-manager && ./setup.py configure --prefix=/usr/local && ./setup.py install --exec-prefix=/usr/local


### PR DESCRIPTION
Current code in Dockerfile is unable to be compiled correctly, because of an error related to .icon-theme.cache.
This pr switch virt-manager branch from current master to release 3.2.0 (latest), so to fix compilation error.

https://forums.unraid.net/topic/84601-support-spaceinvaderone-macinabox/?do=findComment&comment=1085294